### PR TITLE
Use shared pool for pacer cache

### DIFF
--- a/pkg/cc/interceptor.go
+++ b/pkg/cc/interceptor.go
@@ -22,6 +22,8 @@ type BandwidthEstimator interface {
 	WriteRTCP([]rtcp.Packet, interceptor.Attributes) error
 	GetTargetBitrate() int
 	SetTargetBitrate(rate int)
+	SetMinBitrate(rate int)
+	SetMaxBitrate(rate int)
 	OnTargetBitrateChange(f func(bitrate int))
 	GetStats() map[string]interface{}
 	Close() error

--- a/pkg/gcc/adaptive_threshold.go
+++ b/pkg/gcc/adaptive_threshold.go
@@ -92,7 +92,7 @@ func (a *adaptiveThreshold) update(estimate time.Duration) {
 	timeDelta := time.Duration(minInt(int(now.Sub(a.lastUpdate).Milliseconds()), int(maxTimeDelta.Milliseconds()))) * time.Millisecond
 	d := absEstimate - a.thresh
 	add := k * float64(d.Milliseconds()) * float64(timeDelta.Milliseconds())
-	a.thresh += time.Duration(add) * 1000 * time.Microsecond
+	a.thresh += time.Duration(add*1000) * time.Microsecond
 	a.thresh = clampDuration(a.thresh, a.min, a.max)
 	a.lastUpdate = now
 }

--- a/pkg/gcc/delay_based_bwe.go
+++ b/pkg/gcc/delay_based_bwe.go
@@ -105,3 +105,11 @@ func (d *delayController) Close() error {
 func (d *delayController) setTargetBitrate(rate int) {
 	d.rateController.setTargetBitrate(rate)
 }
+
+func (d *delayController) setMinBitrate(rate int) {
+	d.rateController.setMinBitrate(rate)
+}
+
+func (d *delayController) setMaxBitrate(rate int) {
+	d.rateController.setMaxBitrate(rate)
+}

--- a/pkg/gcc/leaky_bucket_pacer.go
+++ b/pkg/gcc/leaky_bucket_pacer.go
@@ -1,7 +1,6 @@
 package gcc
 
 import (
-	"container/list"
 	"errors"
 	"sync"
 	"time"
@@ -12,9 +11,13 @@ import (
 )
 
 var errLeakyBucketPacerPoolCastFailed = errors.New("failed to access leaky bucket pacer pool, cast failed")
+var errLeakyBucketPacerQueueItemsPoolCastFailed = errors.New("failed to access leaky bucket pacer queue items pool, cast failed")
+var errLeakyBucketPacerQueueFull = errors.New("failed to add item to queue: channel is full")
+
+const pacerQueueMaxSize = 10000
 
 type item struct {
-	header     *rtp.Header
+	header     rtp.Header
 	payload    []byte
 	size       int
 	attributes interceptor.Attributes
@@ -26,16 +29,15 @@ type LeakyBucketPacer struct {
 
 	f                 float64
 	targetBitrate     int
-	targetBitrateLock sync.Mutex
+	targetBitrateLock sync.RWMutex
 
 	pacingInterval time.Duration
 
-	qLock sync.RWMutex
-	queue *list.List
-	done  chan struct{}
+	queue       chan *item
+	done        chan struct{}
+	disableCopy bool
 
-	ssrcToWriter map[uint32]interceptor.RTPWriter
-	writerLock   sync.RWMutex
+	ssrcToWriter sync.Map
 }
 
 var pacerBufPool = &sync.Pool{
@@ -44,28 +46,48 @@ var pacerBufPool = &sync.Pool{
 	},
 }
 
+var pacerItemsPool = &sync.Pool{
+	New: func() interface{} {
+		return &item{}
+	},
+}
+
+// PacerOption configures a pacer
+type PacerOption func(*LeakyBucketPacer) error
+
+// PacerDisableCopy bypasses copy of underlying packets.
+// It should be used when you are not re-using underlying buffers of packets that have been written
+func PacerDisableCopy() PacerOption {
+	return func(p *LeakyBucketPacer) error {
+		p.disableCopy = true
+		return nil
+	}
+}
+
 // NewLeakyBucketPacer initializes a new LeakyBucketPacer
-func NewLeakyBucketPacer(initialBitrate int) *LeakyBucketPacer {
+func NewLeakyBucketPacer(initialBitrate int, opts ...PacerOption) (*LeakyBucketPacer, error) {
 	p := &LeakyBucketPacer{
 		log:            logging.NewDefaultLoggerFactory().NewLogger("pacer"),
 		f:              1.5,
 		targetBitrate:  initialBitrate,
 		pacingInterval: 5 * time.Millisecond,
-		qLock:          sync.RWMutex{},
-		queue:          list.New(),
+		queue:          make(chan *item, pacerQueueMaxSize),
 		done:           make(chan struct{}),
-		ssrcToWriter:   map[uint32]interceptor.RTPWriter{},
+	}
+
+	for _, opt := range opts {
+		if err := opt(p); err != nil {
+			return nil, err
+		}
 	}
 
 	go p.Run()
-	return p
+	return p, nil
 }
 
 // AddStream adds a new stream and its corresponding writer to the pacer
 func (p *LeakyBucketPacer) AddStream(ssrc uint32, writer interceptor.RTPWriter) {
-	p.writerLock.Lock()
-	defer p.writerLock.Unlock()
-	p.ssrcToWriter[ssrc] = writer
+	p.ssrcToWriter.Store(ssrc, writer)
 }
 
 // SetTargetBitrate updates the target bitrate at which the pacer is allowed to
@@ -77,8 +99,8 @@ func (p *LeakyBucketPacer) SetTargetBitrate(rate int) {
 }
 
 func (p *LeakyBucketPacer) getTargetBitrate() int {
-	p.targetBitrateLock.Lock()
-	defer p.targetBitrateLock.Unlock()
+	p.targetBitrateLock.RLock()
+	defer p.targetBitrateLock.RUnlock()
 
 	return p.targetBitrate
 }
@@ -86,22 +108,32 @@ func (p *LeakyBucketPacer) getTargetBitrate() int {
 // Write sends a packet with header and payload the a previously registered
 // stream.
 func (p *LeakyBucketPacer) Write(header *rtp.Header, payload []byte, attributes interceptor.Attributes) (int, error) {
-	buf, ok := pacerBufPool.Get().([]byte)
-	if !ok {
-		return 0, errLeakyBucketPacerPoolCastFailed
+	var buf []byte
+	if p.disableCopy {
+		buf = payload
+	} else {
+		var ok bool
+		buf, ok = pacerBufPool.Get().([]byte)
+		if !ok {
+			return 0, errLeakyBucketPacerPoolCastFailed
+		}
+		copy(buf, payload)
 	}
 
-	copy(buf, payload)
-	hdr := header.Clone()
+	qItem, ok := pacerItemsPool.Get().(*item)
+	if !ok {
+		return 0, errLeakyBucketPacerQueueItemsPoolCastFailed
+	}
+	qItem.header = header.Clone()
+	qItem.payload = buf
+	qItem.size = len(payload)
+	qItem.attributes = attributes
 
-	p.qLock.Lock()
-	p.queue.PushBack(&item{
-		header:     &hdr,
-		payload:    buf,
-		size:       len(payload),
-		attributes: attributes,
-	})
-	p.qLock.Unlock()
+	select {
+	case p.queue <- qItem:
+	default:
+		return 0, errLeakyBucketPacerQueueFull
+	}
 
 	return header.MarshalSize() + len(payload), nil
 }
@@ -118,37 +150,50 @@ func (p *LeakyBucketPacer) Run() {
 			return
 		case now := <-ticker.C:
 			budget := int(float64(now.Sub(lastSent).Milliseconds()) * float64(p.getTargetBitrate()) / 8000.0)
-			p.qLock.Lock()
-			for p.queue.Len() != 0 && budget > 0 {
-				p.log.Infof("budget=%v, len(queue)=%v, targetBitrate=%v", budget, p.queue.Len(), p.getTargetBitrate())
-				next, ok := p.queue.Remove(p.queue.Front()).(*item)
-				p.qLock.Unlock()
-				if !ok {
-					p.log.Warnf("failed to access leaky bucket pacer queue, cast failed")
+			for len(p.queue) != 0 && budget > 0 {
+				//p.log.Infof("budget=%v, len(queue)=%v, targetBitrate=%v", budget, len(p.queue), p.getTargetBitrate())
+
+				var next *item
+				var ok bool
+				select {
+				case next, ok = <-p.queue:
+					if !ok {
+						continue
+					}
+				default:
+					p.log.Warnf("failed to get item from queue")
 					continue
 				}
 
-				p.writerLock.RLock()
-				writer, ok := p.ssrcToWriter[next.header.SSRC]
-				p.writerLock.RUnlock()
+				entry, ok := p.ssrcToWriter.Load(next.header.SSRC)
 				if !ok {
 					p.log.Warnf("no writer found for ssrc: %v", next.header.SSRC)
-					pacerBufPool.Put(next.payload)
-					p.qLock.Lock()
+					pacerItemsPool.Put(next)
+					if !p.disableCopy {
+						pacerBufPool.Put(next.payload)
+					}
 					continue
 				}
+				writer := entry.(interceptor.RTPWriter)
 
-				n, err := writer.Write(next.header, (next.payload)[:next.size], next.attributes)
+				if next.attributes == nil {
+					next.attributes = make(interceptor.Attributes)
+				}
+				next.attributes.Set(timeNowAttributesKey, &now)
+
+				n, err := writer.Write(&next.header, (next.payload)[:next.size], next.attributes)
 				if err != nil {
 					p.log.Errorf("failed to write packet: %v", err)
 				}
 				lastSent = now
 				budget -= n
 
-				pacerBufPool.Put(next.payload)
-				p.qLock.Lock()
+				pacerItemsPool.Put(next)
+
+				if !p.disableCopy {
+					pacerBufPool.Put(next.payload)
+				}
 			}
-			p.qLock.Unlock()
 		}
 	}
 }

--- a/pkg/gcc/rate_controller.go
+++ b/pkg/gcc/rate_controller.go
@@ -172,3 +172,15 @@ func (c *rateController) setTargetBitrate(rate int) {
 	defer c.lock.Unlock()
 	c.target = rate
 }
+
+func (c *rateController) setMinBitrate(rate int) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.minBitrate = rate
+}
+
+func (c *rateController) setMaxBitrate(rate int) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.maxBitrate = rate
+}

--- a/pkg/nack/responder_interceptor.go
+++ b/pkg/nack/responder_interceptor.go
@@ -15,7 +15,7 @@ type ResponderInterceptorFactory struct {
 }
 
 type packetFactory interface {
-	NewPacket(header *rtp.Header, payload []byte) (*retainablePacket, error)
+	NewPacket(header *rtp.Header, payload []byte) (retainablePacket, error)
 }
 
 // NewInterceptor constructs a new ResponderInterceptor
@@ -111,7 +111,7 @@ func (n *ResponderInterceptor) BindLocalStream(info *interceptor.StreamInfo, wri
 		if err != nil {
 			return 0, err
 		}
-		sendBuffer.add(pkt)
+		sendBuffer.add(&pkt)
 		return writer.Write(header, payload, attributes)
 	})
 }

--- a/pkg/nack/send_buffer_test.go
+++ b/pkg/nack/send_buffer_test.go
@@ -20,7 +20,7 @@ func TestSendBuffer(t *testing.T) {
 				seq := start + n
 				pkt, err := pm.NewPacket(&rtp.Header{SequenceNumber: seq}, nil)
 				require.NoError(t, err)
-				sb.add(pkt)
+				sb.add(&pkt)
 			}
 		}
 
@@ -77,7 +77,7 @@ func TestSendBuffer_Overridden(t *testing.T) {
 	originalBytes := []byte("originalContent")
 	pkt, err := pm.NewPacket(&rtp.Header{SequenceNumber: 1}, originalBytes)
 	require.NoError(t, err)
-	sb.add(pkt)
+	sb.add(&pkt)
 
 	// change payload
 	copy(originalBytes, "altered")
@@ -90,7 +90,7 @@ func TestSendBuffer_Overridden(t *testing.T) {
 	// ensure original packet is released
 	pkt, err = pm.NewPacket(&rtp.Header{SequenceNumber: 2}, originalBytes)
 	require.NoError(t, err)
-	sb.add(pkt)
+	sb.add(&pkt)
 	require.Equal(t, 0, retrieved.count)
 
 	require.Nil(t, sb.get(1))
@@ -98,7 +98,7 @@ func TestSendBuffer_Overridden(t *testing.T) {
 
 // this test is only useful when being run with the race detector, it won't fail otherwise:
 //
-//     go test -race ./pkg/nack/
+//	go test -race ./pkg/nack/
 func TestSendBuffer_Race(t *testing.T) {
 	pm := newPacketManager()
 	for _, start := range []uint16{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 511, 512, 513, 32767, 32768, 32769, 65527, 65528, 65529, 65530, 65531, 65532, 65533, 65534, 65535} {
@@ -112,7 +112,7 @@ func TestSendBuffer_Race(t *testing.T) {
 				seq := start + n
 				pkt, err := pm.NewPacket(&rtp.Header{SequenceNumber: seq}, nil)
 				require.NoError(t, err)
-				sb.add(pkt)
+				sb.add(&pkt)
 			}
 		}
 


### PR DESCRIPTION
#### Summary

Using a shared pool (green line) showed some decent improvements on spike allocations.

![image](https://user-images.githubusercontent.com/1832946/228087259-d87b113b-35ea-4eb2-89d2-c51dc1354381.png)

![image](https://user-images.githubusercontent.com/1832946/228087552-e5b7d96e-d27e-444a-86c0-2dbc1c4b6839.png)
